### PR TITLE
Fix/proper teaser SKU

### DIFF
--- a/cartridges/int_turnto_sfra_v5/cartridge/client/default/js/product/detail.js
+++ b/cartridges/int_turnto_sfra_v5/cartridge/client/default/js/product/detail.js
@@ -1,6 +1,7 @@
 'use strict';
 var base = require('base/product/base');
 var teasersModules = require('../teaser/teasersModules');
+var serviceFactory = require('*/cartridge/scripts/util/ServiceFactory');
 
 module.exports = {
     availability: base.availability,
@@ -57,9 +58,13 @@ module.exports = {
                 $('.product-detail:not(".bundle-item")').data('pid', response.data.product.id);
             }
             // eslint-disable-next-line no-undef
-            TurnToCmd('set', { sku: response.data.product.id }); // eslint-disable-line new-cap
-            teasersModules.loadTeaserCounts(response.data.product.id);
-            // TurnToCmd('gallery.set', { skus: [response.data.product.id] });
+            if (serviceFactory.getUseVaraintsPreference()) {
+                // Only run if "useVariants" setting is enabled
+                TurnToCmd('set', { sku: response.data.product.id }); // eslint-disable-line new-cap
+                teasersModules.loadTeaserCounts(response.data.product.id);
+                TurnToCmd('gallery.set', { skus: [response.data.product.id] });
+            }
+            
         });
     },
     updateAddToCart: function () {

--- a/cartridges/int_turnto_sfra_v5/cartridge/client/default/js/teasers.js
+++ b/cartridges/int_turnto_sfra_v5/cartridge/client/default/js/teasers.js
@@ -6,6 +6,6 @@ var teasersModules = require('./teaser/teasersModules');
 $(document).ready(function () {
 	// PDP teasers only
     if ($('span.product-id').text().length) {
-        teasersModules.loadTeaserCounts($('span.product-id').text());
+        teasersModules.loadTeaserCounts($('span.productsku').text());
     }
 });


### PR DESCRIPTION
- Modify product detail code to only update SKU when a user selects a different variant IF "useVariants" is set to "Yes"
- Make sure teaser uses the correct SKU based on "useVariants" setting