### PR TITLE
make sure sanitizeStr replaces whitespace with a space, not empty string

### DIFF
--- a/cartridges/int_turnto_core_v5/cartridge/scripts/util/TurnToHelperUtil.js
+++ b/cartridges/int_turnto_core_v5/cartridge/scripts/util/TurnToHelperUtil.js
@@ -120,7 +120,7 @@ var TurnToHelper = {
      sanitizeStr: function (str, replace) {
         // If string is null, return empty string
         var clnStr = TurnToHelper.replaceNull(str, '');
-        var replaceStr = replace || '';
+        var replaceStr = replace || ' ';
         // Replace any whitespaces with the given string
         return clnStr.replace(/\s+/g, replaceStr);
     },


### PR DESCRIPTION
# Make sure product titles have whitespaces replace with a space, not empty string

### Intent or Business Objective
Currently the catalog export strips all spaces from product titles. This is because sanitizeStr function replaces whitespace with empty string, not a space

---

### Questions

#### Does this PR depend on any other changes?

- [ ] This pull request depends on other changes

##### If yes for above, Include links to the additional PR(s) below:

n/a

#### Have test cases been created?
- [ ] Test cases have been created

---

### Lessons learned? Questions for reviewers?
Be more careful with integrating changes

---

### Checklist When Creating PR

- [X] Tested locally - either manually via UI or via tests
- [ ] Tests - if this is a bug fix, make sure a test is added to catch the bug going forward
- [ ] Linting/Styling changes
- [ ] Appropriate logging added to feature
- [ ] Appropriate monitoring added to feature
- [ ] Remove debug logging / redundant code / copy+paste stuff
- [ ] Squash and merge the changes to prod after approval
- [ ] Futher details on [reviewers](https://pixlee-wiki.atlassian.net/wiki/spaces/PD/pages/790003746/Pull+Requests)
- [ ] Further details on [things to do before/after pushing to production](https://pixlee-wiki.atlassian.net/wiki/spaces/PD/pages/792264797/Engineering+Production+Release+Checklist)