### PR TITLE
TSD-128: Remove failed orders from export

### DIFF
--- a/cartridges/int_turnto_core_v5/cartridge/scripts/jobsteps/ExportHistoricalOrders.js
+++ b/cartridges/int_turnto_core_v5/cartridge/scripts/jobsteps/ExportHistoricalOrders.js
@@ -13,11 +13,12 @@
 var Site = require('dw/system/Site');
 var File = require('dw/io/File');
 var FileWriter = require('dw/io/FileWriter');
+var Order = require('dw/order/Order');
 var OrderMgr = require('dw/order/OrderMgr');
 var Calendar = require('dw/util/Calendar');
 var Status = require('dw/system/Status');
 
-/* Script Modules*/
+/* Script Modules */
 var TurnToHelper = require('*/cartridge/scripts/util/TurnToHelperUtil');
 var OrderWriterHelper = require('*/cartridge/scripts/util/OrderWriterHelper');
 
@@ -59,8 +60,15 @@ var run = function run() {
                 var dateLimit = new Calendar();
                 dateLimit.add(Calendar.DAY_OF_YEAR, historicalOrderDays * -1);
 
-                var query = 'creationDate >= {0} AND customerLocaleID = {1}';
-                var orders = OrderMgr.searchOrders(query, 'creationDate asc', dateLimit.getTime(), currentLocale);
+                var query = 'creationDate >= {0} AND customerLocaleID = {1} AND status != {2} AND status != {3}';
+                var orders = OrderMgr.searchOrders(
+                    query,
+                    'creationDate asc',
+                    dateLimit.getTime(),
+                    currentLocale,
+                    Order.ORDER_STATUS_CANCELLED,
+                    Order.ORDER_STATUS_FAILED
+                );
 
                 if (orders.count !== 0) {
                     // Create a TurnTo directory if one doesn't already exist
@@ -86,9 +94,7 @@ var run = function run() {
                             OrderWriterHelper.writeOrderData(order, fileWriter, currentLocale);
                         }
                     } finally {
-                        if (orders != null) {
-                            orders.close();
-                        }
+                        orders.close();
                     }
                 }
             } catch (e) {

--- a/cartridges/int_turnto_core_v5/cartridge/scripts/jobsteps/ExportHistoricalOrdersByDate.js
+++ b/cartridges/int_turnto_core_v5/cartridge/scripts/jobsteps/ExportHistoricalOrdersByDate.js
@@ -13,6 +13,7 @@
 var Site = require('dw/system/Site');
 var File = require('dw/io/File');
 var FileWriter = require('dw/io/FileWriter');
+var Order = require('dw/order/Order');
 var OrderMgr = require('dw/order/OrderMgr');
 var Status = require('dw/system/Status');
 
@@ -60,9 +61,15 @@ var run = function run() {
 
             try {
                 // query orders by order system attribute "customerLocaleID" and specify creation date
-                var query = 'creationDate >= {0} AND customerLocaleID = {1}';
-                var orders = OrderMgr.searchOrders(query, 'creationDate asc', historicalOrderDate, currentLocale);
-
+                var query = 'creationDate >= {0} AND customerLocaleID = {1} AND status != {2} AND status != {3}';
+                var orders = OrderMgr.searchOrders(
+                    query,
+                    'creationDate asc',
+                    historicalOrderDate,
+                    currentLocale,
+                    Order.ORDER_STATUS_CANCELLED,
+                    Order.ORDER_STATUS_FAILED
+                );
                 if (orders.count !== 0) {
                     // Create a TurnTo directory if one doesn't already exist
                     var turntoDir = new File(impexPath + File.SEPARATOR + 'TurnTo' + File.SEPARATOR + currentLocale);
@@ -87,9 +94,7 @@ var run = function run() {
                             OrderWriterHelper.writeOrderData(order, fileWriter, currentLocale);
                         }
                     } finally {
-                        if (orders != null) {
-                            orders.close();
-                        }
+                        orders.close();
                     }
                 }
             } finally {


### PR DESCRIPTION
[TSD-128](https://emplifi.atlassian.net/browse/TSD-128) Add status != Order.ORDER_STATUS_CANCELLED and Order.ORDER_STATUS_FAILED to searchOrders query to filter our cancelled and failed order from orders being sent to TT in order export feed.
Removed orders null check because orders.count would error if it is null.